### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,86 @@
 # RuboCop::Packaging
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/rubocop/packaging`. To experiment with that code, run `bin/console` for an interactive prompt.
+`RuboCop::Packaging` is an extension of [RuboCop](https://rubocop.org/),
+which is a Ruby static code analyzer (a.k.a. linter) and code formatter.
 
-TODO: Delete this and the text above, and describe your gem
+It contains a set of Cops which enforces some of the guidelines that
+are expected of upstream maintainers so that the downstream can build
+their packages in a clean environment without any problems.  
+Some of the other basic guidelines can be found
+[here](https://wiki.debian.org/Teams/Ruby/RubyExtras/UpstreamDevelopers).
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rubocop-packaging', require: false
+gem 'rubocop-packaging'
 ```
 
 And then execute:
 
-    $ bundle install
+```bash
+$ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install rubocop-packaging
+```bash
+$ gem install rubocop-packaging
+```
 
 ## Usage
 
-TODO: Write usage instructions here
+You need to tell RuboCop to load the Packaging extension. There are three
+ways to do this:
+
+### RuboCop configuration file
+
+Put this into your `.rubocop.yml` file:
+
+```yaml
+require: rubocop-packaging
+```
+
+Alternatively, use the following array notation when specifying multiple
+extensions:
+
+```yaml
+require:
+  - rubocop-other-extension
+  - rubocop-packaging
+```
+
+Now you can run `rubocop` and it will automatically load the RuboCop Packaging
+cops together with the standard cops.
+
+### Command line
+
+```bash
+rubocop --require rubocop-packaging
+```
+
+### Rake task
+
+```ruby
+RuboCop::RakeTask.new do |task|
+  task.requires << 'rubocop-packaging'
+end
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then,
+run `rake spec` to run the tests. You can also run `bin/console` for an
+interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/rubocop-packaging. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/rubocop-packaging/blob/master/CODE_OF_CONDUCT.md).
+As always, bug reports and pull requests are heartily welcomed! 💖  
+This project is intended to be a safe and welcoming space for collaboration.
 
-
-## Code of Conduct
-
-Everyone interacting in the RuboCop::Packaging project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/rubocop-packaging/blob/master/CODE_OF_CONDUCT.md).
+## License
+`rubocop-packaging` is available as open-source under the
+[MIT License](https://github.com/utkarsh2102/rubocop-packaging/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 `RuboCop::Packaging` is an extension of [RuboCop](https://rubocop.org/),
 which is a Ruby static code analyzer (a.k.a. linter) and code formatter.
 
-It contains a set of Cops which enforces some of the guidelines that
-are expected of upstream maintainers so that the downstream can build
-their packages in a clean environment without any problems.  
+It helps enforcing some of the guidelines that are expected of upstream
+maintainers so that the downstream can build their packages in a clean
+environment without any problems.  
 Some of the other basic guidelines can be found
 [here](https://wiki.debian.org/Teams/Ruby/RubyExtras/UpstreamDevelopers).
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ RuboCop::RakeTask.new
 task default: %i[
   spec
   rubocop
+  generate_cops_documentation
 ]
 
 desc 'Generate a new cop with a template'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,6 @@
 # This is the default configuration file.
 
 Packaging/GemspecGit:
-  Description: 'Use pure Ruby alternative instead of `git ls-files`'
+  Description: 'Use pure Ruby alternative instead of `git ls-files`.'
   Enabled: true
   VersionAdded: '0.86'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,0 +1,5 @@
+name: rubocop-packaging
+title: RuboCop Packaging
+version: master
+nav:
+  - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,0 +1,6 @@
+* xref:index.adoc[Home]
+* xref:installation.adoc[Installation]
+* xref:usage.adoc[Usage]
+* xref:cops.adoc[Cops]
+* Cops Documentation
+** xref:cops_packaging.adoc[Packaging]

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -1,0 +1,7 @@
+// START_COP_LIST
+
+= Department xref:cops_packaging.adoc[Packaging]
+
+* xref:cops_packaging.adoc#packaginggemspecgit[Packaging/GemspecGit]
+
+// END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -1,0 +1,59 @@
+= Packaging
+
+== Packaging/GemspecGit
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| No
+| 0.86
+| -
+|===
+
+This cop is used to identify the usage of `git ls-files`
+and suggests to use a plain Ruby alternative, like `Dir`,
+`Dir.glob` or `Rake::FileList` instead.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+Gem::Specification.new do |spec|
+  spec.files = `git ls-files`.split('\n')
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.files         = `git ls-files`.split('\n')
+  spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
+  spec.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
+  spec.test_files    = Dir['spec/**/*']
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Dir.glob('lib/**/*')
+  spec.test_files    = Dir.glob('test/{functional,test}/*')
+  spec.executables   = Dir.glob('bin/*').map{ |f| File.basename(f) }
+end
+----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,8 +3,8 @@
 `RuboCop::Packaging` is an extension of [RuboCop](https://rubocop.org/),
 which is a Ruby static code analyzer (a.k.a. linter) and code formatter.
 
-It contains a set of Cops which enforces some of the guidelines that
-are expected of upstream maintainers so that the downstream can build
-their packages in a clean environment without any problems.
+It helps enforcing some of the guidelines that are expected of upstream
+maintainers so that the downstream can build their packages in a clean
+environment without any problems.  
 Some of the other basic guidelines can be found
 [here](https://wiki.debian.org/Teams/Ruby/RubyExtras/UpstreamDevelopers).

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,0 +1,10 @@
+= RuboCop Packaging
+
+`RuboCop::Packaging` is an extension of [RuboCop](https://rubocop.org/),
+which is a Ruby static code analyzer (a.k.a. linter) and code formatter.
+
+It contains a set of Cops which enforces some of the guidelines that
+are expected of upstream maintainers so that the downstream can build
+their packages in a clean environment without any problems.
+Some of the other basic guidelines can be found
+[here](https://wiki.debian.org/Teams/Ruby/RubyExtras/UpstreamDevelopers).

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -1,0 +1,22 @@
+= Installation
+
+Add this line to your application's Gemfile:
+
+[source,ruby]
+----
+gem 'rubocop-packaging', require: false
+----
+
+And then execute:
+
+[source,bash]
+----
+$ bundle install
+----
+
+Or install it yourself as:
+
+[source,bash]
+----
+$ gem install rubocop-packaging
+----

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,0 +1,42 @@
+= Usage
+
+You need to tell RuboCop to load the Packaging extension. There are three
+ways to do this:
+
+== RuboCop configuration file
+
+Put this into your `.rubocop.yml` file:
+
+[source,yaml]
+----
+require: rubocop-packaging  
+----
+
+Alternatively, use the following array notation when specifying multiple
+extensions:
+
+[source,yaml]
+----
+require:
+  - rubocop-other-extension
+  - rubocop-packaging
+----
+
+Now you can run `rubocop` and it will automatically load the RuboCop Packaging  
+cops together with the standard cops.
+
+== Command line
+
+[source,bash]
+----
+rubocop --require rubocop-packaging
+----
+
+== Rake task
+
+[source,ruby]
+----
+RuboCop::RakeTask.new do |task|
+  task.requires << 'rubocop-packaging'
+end
+----

--- a/lib/rubocop/cop/packaging/gemspec_git.rb
+++ b/lib/rubocop/cop/packaging/gemspec_git.rb
@@ -82,7 +82,7 @@ module RuboCop
         end
 
         # This method is called from inside `#def_node_search`.
-        # It is used to find strings which starts with 'git'.
+        # It is used to find strings which start with 'git'.
         def starts_with_git?(str)
           str.start_with?('git')
         end

--- a/lib/rubocop/cop/packaging/gemspec_git.rb
+++ b/lib/rubocop/cop/packaging/gemspec_git.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Rubocop module
-module RuboCop
-  # Cop module
-  module Cop
-    # Packaging module
-    module Packaging
+module RuboCop # :nodoc:
+  module Cop # :nodoc:
+    module Packaging # :nodoc:
       # This cop is used to identify the usage of `git ls-files`
       # and suggests to use a plain Ruby alternative, like `Dir`,
       # `Dir.glob` or `Rake::FileList` instead.
@@ -68,7 +65,7 @@ module RuboCop
 
         # Extended from the Cop class.
         # More about the `#investigate` method can be found here:
-        # https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/cop.rb
+        # https://github.com/rubocop-hq/rubocop/blob/59543c8e2b66bff249de131fa9105f3eb11e9edb/lib/rubocop/cop/cop.rb#L13-L25
         #
         # Processing of the AST happens here.
         def investigate(processed_source)

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -187,7 +187,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   # rubocop:disable Metrics/AbcSize
   def print_cops_of_department(cops, department, config)
     selected_cops = cops_of_department(cops, department).select do |cop|
-      cop.to_s.start_with?('RuboCop::Cop::Performance')
+      cop.to_s.start_with?('RuboCop::Cop::Packaging')
     end
     return if selected_cops.empty?
 
@@ -231,7 +231,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   # rubocop:disable Metrics/AbcSize
   def table_of_content_for_department(cops, department)
     selected_cops = cops_of_department(cops, department.to_sym).select do |cop|
-      cop.to_s.start_with?('RuboCop::Cop::Performance')
+      cop.to_s.start_with?('RuboCop::Cop::Packaging')
     end
     return if selected_cops.empty?
 


### PR DESCRIPTION
Hi,

This PR documents the entire source code and also adds the `docs/` directory.
For a visual representation of the change, you can check the [documentation branch](https://github.com/utkarsh2102/rubocop-packaging/tree/documentation).

The source code is now 100% documented:
```bash
➜  rubocop-packaging git:(master) rake generate_cops_documentation
Files:           1
Modules:         3 (    0 undocumented)
Classes:         1 (    0 undocumented)
Constants:       1 (    0 undocumented)
Attributes:      0 (    0 undocumented)
Methods:         2 (    0 undocumented)
 100.00% documented
```

Please don't squash the commits as they each represent a separate change. 