### PR TITLE
Implement the new RelativeRequireToLib cop + add tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,10 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.4
 
+Packaging/RelativeRequireToLib:
+  Include:
+    - spec/**/*.rb
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-packaging.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,3 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - tasks/*.rake
-
-Layout/LineLength:
-  Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 before_install: gem install bundler -v 2.1.4
 rvm:
-  - 2.4.10
   - 2.5.8
   - 2.6.6
   - 2.7.1

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ RuboCop::RakeTask.new
 task default: %i[
   spec
   rubocop
-  generate_cops_documentation
 ]
 
 desc 'Generate a new cop with a template'

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,3 +4,8 @@ Packaging/GemspecGit:
   Description: 'Use pure Ruby alternative instead of `git ls-files`.'
   Enabled: true
   VersionAdded: '0.86'
+
+Packaging/RelativeRequireToLib:
+  Description: 'Avoid using `require` with relative path to lib.'
+  Enabled: true
+  VersionAdded: '0.86'

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,6 @@ Packaging/GemspecGit:
   VersionAdded: '0.86'
 
 Packaging/RelativeRequireToLib:
-  Description: 'Avoid using `require` with relative path to lib.'
+  Description: 'Avoid using `require_relative` with relative path to lib.'
   Enabled: true
-  VersionAdded: '0.86'
+  VersionAdded: '0.89'

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,9 +3,10 @@
 Packaging/GemspecGit:
   Description: 'Use pure Ruby alternative instead of `git ls-files`.'
   Enabled: true
-  VersionAdded: '0.86'
+  VersionAdded: '0.1'
+  VersionChanged: '0.1'
 
 Packaging/RelativeRequireToLib:
   Description: 'Avoid using `require_relative` with relative path to lib.'
   Enabled: true
-  VersionAdded: '0.89'
+  VersionAdded: '0.2'

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -3,5 +3,6 @@
 = Department xref:cops_packaging.adoc[Packaging]
 
 * xref:cops_packaging.adoc#packaginggemspecgit[Packaging/GemspecGit]
+* xref:cops_packaging.adoc#packagingrelativerequiretolib[Packaging/RelativeRequireToLib]
 
 // END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -57,3 +57,40 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir.glob('bin/*').map{ |f| File.basename(f) }
 end
 ----
+
+== Packaging/RelativeRequireToLib
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| No
+| 0.89
+| -
+|===
+
+This cop is used to identify the `require_relative` calls,
+mapping to the "lib" directory and suggests to use `require`
+instead.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+require_relative 'lib/foo.rb'
+
+# bad
+require_relative '../../lib/foo/bar'
+
+# good
+require 'foo.rb'
+
+# good
+require 'foo/bar'
+
+# good
+require_relative 'spec_helper'
+require_relative 'foo/bar'
+----

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -8,8 +8,8 @@
 | Enabled
 | Yes
 | No
-| 0.86
-| -
+| 0.1
+| 0.1
 |===
 
 This cop is used to identify the usage of `git ls-files`
@@ -66,7 +66,7 @@ end
 | Enabled
 | Yes
 | No
-| 0.89
+| 0.2
 | -
 |===
 

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -34,16 +34,11 @@ module RuboCop # :nodoc:
         # This method is called from inside `#def_node_search`.
         # It is used to find the strings that uses relative path.
         def starts_with_relative_path?(str)
-          root_dir = get_root
+          root_dir = RuboCop::ConfigLoader.project_root
           relative_dir = File.expand_path(str, @file_directory)
           relative_dir.delete_prefix!(root_dir + '/')
           relative_dir.start_with?('lib')
           # str.match?(%r{.*\./lib/})
-        end
-
-        def get_root(*)
-          # FIXME
-          '/some'
         end
       end
     end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop # :nodoc:
+  module Cop # :nodoc:
+    module Packaging # :nodoc:
+      # TODO
+      # Write about this cop.
+      # Write bad and good methods.
+      # Help from cop/lint/redundant_require_statement.rb.
+      #
+      class RelativeRequireToLib < Cop
+        # This is the message that will be displayed when RuboCop finds an
+        # offense of using `require` with relative path to lib.
+        MSG = 'Avoid using `require` with relative path to lib.'
+
+        def_node_matcher :require?, <<~PATTERN
+          (send nil? :require
+            (str {#starts_with_relative_path?}))
+        PATTERN
+
+        # Extended method.
+        # TODO: document it.
+        def on_send(node)
+          return unless require?(node)
+
+          add_offense(node)
+        end
+
+        # This method is called from inside `#def_node_search`.
+        # It is used to find the strings that uses relative path.
+        def starts_with_relative_path?(str)
+          str.match?(%r{.*\.\./lib/})
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -14,9 +14,9 @@ module RuboCop # :nodoc:
         MSG = 'Avoid using `require` with relative path to lib.'
 
         def_node_matcher :require?, <<~PATTERN
-          {(send nil? :require (str #starts_with_relative_path?))
-           (send nil? :require (send (const nil? :File) :expand_path (str #starts_with_relative_path?) {(str _) (send nil? _)}))
-           (send nil? :require (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #starts_with_relative_path?)))}
+          {(send nil? {:require :require_relative} (str #starts_with_relative_path?))
+           (send nil? {:require :require_relative} (send (const nil? :File) :expand_path (str #starts_with_relative_path?) {(str _) (send nil? _)}))
+           (send nil? {:require :require_relative} (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #starts_with_relative_path?)))}
         PATTERN
 
         # Extended method.

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -13,16 +13,20 @@ module RuboCop # :nodoc:
         # offense of using `require` with relative path to lib.
         MSG = 'Avoid using `require` with relative path to lib.'
 
-        def_node_matcher :require?, <<~PATTERN
-          {(send nil? {:require :require_relative} (str #starts_with_relative_path?))
-           (send nil? {:require :require_relative} (send (const nil? :File) :expand_path (str #starts_with_relative_path?) {(str _) (send nil? _)}))
-           (send nil? {:require :require_relative} (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #starts_with_relative_path?)))}
+        def_node_matcher :require_relative, <<~PATTERN
+          (send nil? :require_relative
+            (str #starts_with_relative_path?))
         PATTERN
+
+        def investigate(processed_source)
+          @file_path = processed_source.file_path
+          @file_directory = File.dirname(@file_path)
+        end
 
         # Extended method.
         # TODO: document it.
         def on_send(node)
-          return unless require?(node)
+          return unless require_relative(node)
 
           add_offense(node)
         end
@@ -30,7 +34,16 @@ module RuboCop # :nodoc:
         # This method is called from inside `#def_node_search`.
         # It is used to find the strings that uses relative path.
         def starts_with_relative_path?(str)
-          str.match?(%r{.*\./lib/})
+          root_dir = get_root
+          relative_dir = File.expand_path(str, @file_directory)
+          relative_dir.delete_prefix!(root_dir + '/')
+          relative_dir.start_with?('lib')
+          # str.match?(%r{.*\./lib/})
+        end
+
+        def get_root(*)
+          # FIXME
+          '/some'
         end
       end
     end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -14,8 +14,9 @@ module RuboCop # :nodoc:
         MSG = 'Avoid using `require` with relative path to lib.'
 
         def_node_matcher :require?, <<~PATTERN
-          (send nil? :require
-            (str {#starts_with_relative_path?}))
+          {(send nil? :require (str #starts_with_relative_path?))
+           (send nil? :require (send (const nil? :File) :expand_path (str #starts_with_relative_path?) {(str _) (send nil? _)}))
+           (send nil? :require (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #starts_with_relative_path?)))}
         PATTERN
 
         # Extended method.
@@ -29,7 +30,7 @@ module RuboCop # :nodoc:
         # This method is called from inside `#def_node_search`.
         # It is used to find the strings that uses relative path.
         def starts_with_relative_path?(str)
-          str.match?(%r{.*\.\./lib/})
+          str.match?(%r{.*\./lib/})
         end
       end
     end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -3,42 +3,65 @@
 module RuboCop # :nodoc:
   module Cop # :nodoc:
     module Packaging # :nodoc:
-      # TODO
-      # Write about this cop.
-      # Write bad and good methods.
-      # Help from cop/lint/redundant_require_statement.rb.
+      # This cop is used to identify the `require_relative` calls,
+      # mapping to the "lib" directory and suggests to use `require`
+      # instead.
       #
-      class RelativeRequireToLib < Cop
+      # @example
+      #
+      #   # bad
+      #   require_relative 'lib/foo.rb'
+      #
+      #   # bad
+      #   require_relative '../../lib/foo/bar'
+      #
+      #   # good
+      #   require 'foo.rb'
+      #
+      #   # good
+      #   require 'foo/bar'
+      #
+      #   # good
+      #   require_relative 'spec_helper'
+      #   require_relative 'foo/bar'
+      #
+      class RelativeRequireToLib < Base
         # This is the message that will be displayed when RuboCop finds an
-        # offense of using `require` with relative path to lib.
-        MSG = 'Avoid using `require` with relative path to lib.'
+        # offense of using `require_relative` with relative path to lib.
+        MSG = 'Avoid using `require_relative` with relative path to lib. ' \
+          'Use `require` instead.'
 
         def_node_matcher :require_relative, <<~PATTERN
           (send nil? :require_relative
             (str #starts_with_relative_path?))
         PATTERN
 
-        def investigate(processed_source)
+        # Extended from the Base class.
+        # More about the `#on_new_investigation` method can be found here:
+        # https://github.com/rubocop-hq/rubocop/blob/343f62e4555be0470326f47af219689e21c61a37/lib/rubocop/cop/base.rb
+        #
+        # Processing of the AST happens here.
+        def on_new_investigation
           @file_path = processed_source.file_path
           @file_directory = File.dirname(@file_path)
         end
 
-        # Extended method.
-        # TODO: document it.
+        # Extended from AST::Traversal.
+        # More about the `#on_send` method can be found here:
+        # https://github.com/rubocop-hq/rubocop-ast/blob/08d0f49a47af1e9a30a6d8f67533ba793c843d67/lib/rubocop/ast/traversal.rb#L112
         def on_send(node)
           return unless require_relative(node)
 
           add_offense(node)
         end
 
-        # This method is called from inside `#def_node_search`.
-        # It is used to find the strings that uses relative path.
+        # This method is called from inside `#def_node_matcher`.
+        # It is used to find paths which starts with "lib".
         def starts_with_relative_path?(str)
           root_dir = RuboCop::ConfigLoader.project_root
           relative_dir = File.expand_path(str, @file_directory)
           relative_dir.delete_prefix!(root_dir + '/')
           relative_dir.start_with?('lib')
-          # str.match?(%r{.*\./lib/})
         end
       end
     end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -59,9 +59,7 @@ module RuboCop # :nodoc:
         # It is used to find paths which starts with "lib".
         def target_falls_in_lib?(str)
           root_dir = RuboCop::ConfigLoader.project_root
-          relative_dir = File.expand_path(str, @file_directory)
-          relative_dir.delete_prefix!(root_dir + '/')
-          relative_dir.start_with?('lib')
+          File.expand_path(str, @file_directory).start_with?(root_dir + '/lib')
         end
       end
     end

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -33,7 +33,7 @@ module RuboCop # :nodoc:
 
         def_node_matcher :require_relative, <<~PATTERN
           (send nil? :require_relative
-            (str #starts_with_relative_path?))
+            (str #target_falls_in_lib?))
         PATTERN
 
         # Extended from the Base class.
@@ -57,7 +57,7 @@ module RuboCop # :nodoc:
 
         # This method is called from inside `#def_node_matcher`.
         # It is used to find paths which starts with "lib".
-        def starts_with_relative_path?(str)
+        def target_falls_in_lib?(str)
           root_dir = RuboCop::ConfigLoader.project_root
           relative_dir = File.expand_path(str, @file_directory)
           relative_dir.delete_prefix!(root_dir + '/')

--- a/lib/rubocop/cop/packaging_cops.rb
+++ b/lib/rubocop/cop/packaging_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'packaging/gemspec_git'
+require_relative 'packaging/relative_require_to_lib'

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
-  spec.add_development_dependency   'bump', '>= 0.8.0'
-  spec.add_development_dependency   'pry', '>= 0.13.0'
+  spec.add_development_dependency   'bump', '~> 0.8'
+  spec.add_development_dependency   'pry', '~> 0.13'
   spec.add_development_dependency   'rake', '~> 13.0'
   spec.add_development_dependency   'rspec', '~> 3.0'
   spec.add_development_dependency   'yard', '~> 0.9'
-  spec.add_runtime_dependency       'rubocop', '>= 0.75.0'
+  spec.add_runtime_dependency       'rubocop', '~> 0.88'
 end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -7,145 +7,98 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
 
   let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
 
-  let(:path) { './../..' }
+  let(:processed_source) { parse_source(source) }
 
-  it 'registers an offense when using `require` with relative path to rubocop' do
-    expect_offense(<<~RUBY)
-      require '../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
+  before do
+    allow(processed_source.buffer)
+      .to receive(:name).and_return(filename)
+    _investigate(cop, processed_source)
   end
 
-  it 'registers an offense when using `require_relative` with relative path to rubocop' do
-    expect_offense(<<~RUBY)
-      require_relative '../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
+  context 'when `require_relative` call lies outside spec/' do
+    let(:filename) { '/some/spec/foo_spec.rb' }
+    let(:source) { 'require_relative "../lib/foo.rb"' }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        #{source}
+        #{'^' * source.length} #{message}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `require` with relative path twice' do
-    expect_offense(<<~RUBY)
-      require '../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-      require '../lib/rubocop/file'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
+  context 'when `require_relative` call with nested path lies outside spec/' do
+    let(:filename) { '/some/spec/rubocop/cop/foo_spec.rb' }
+    let(:source) { 'require_relative "../../../lib/foo.rb"' }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        #{source}
+        #{'^' * source.length} #{message}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `require_relative` with relative path twice' do
-    expect_offense(<<~RUBY)
-      require_relative '../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+  context 'when one `require_relative` call lies outside spec/' do
+    let(:filename) { '/some/spec/foo_spec.rb' }
+    let(:source) { <<~RUBY.chomp }
+      require_relative 'spec_helper'
       require_relative '../lib/rubocop/file'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        #{source}
+        #{'^' * 38} #{message}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `require` with (more) relative path to rubocop' do
-    expect_offense(<<~RUBY)
-      require '../../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'registers an offense when using `require_relative` with (more) relative path to rubocop' do
-    expect_offense(<<~RUBY)
-      require_relative '../../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'registers an offense when using `unshift` and `require` with relative path to file.rb' do
-    expect_offense(<<~RUBY)
+  context 'when `require_relative` call with `unshift` lies outside spec/' do
+    let(:filename) { '/some/spec/foo_spec.rb' }
+    let(:source) { <<~RUBY.chomp }
       $:.unshift('../lib')
-      require '../lib/file.rb'
-      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      require_relative "../lib/file"
     RUBY
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        #{source}
+        #{'^' * 30} #{message}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `unshift` and `require_relative` with relative path to file.rb' do
-    expect_offense(<<~RUBY)
-      $:.unshift('../lib')
-      require_relative '../lib/file.rb'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
+  context 'when the `require_relative` call to `lib` lies inside spec/' do
+    let(:filename) { '/some/specs/rubocop/cop/foo_spec.rb' }
+    let(:source) { 'require_relative "../lib/foo.rb"' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        #{source}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `require` with a variable and a relative path' do
-    expect_offense(<<~RUBY)
-      require "#{path}/../lib/rubocop"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
+  context 'when the `require_relative` call lies inside spec/' do
+    let(:filename) { '/some/specs/rubocop/cop/foo_spec.rb' }
+    let(:source) { 'require_relative "../foo.rb"' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        #{source}
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `require_relative` with a variable and a relative path' do
-    expect_offense(<<~RUBY)
-      require_relative "#{path}/../lib/rubocop"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
+  context 'when the `require_relative` call lies inside spec/' do
+    let(:filename) { '/some/specs/foo_spec.rb' }
+    let(:source) { 'require_relative "spec/rubocop/bar"' }
 
-  it 'registers an offense when using `require` with `File.expand_path` and `__FILE__`' do
-    expect_offense(<<~RUBY)
-      require File.expand_path('../lib/rubocop', __FILE__)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'registers an offense when using `require` with `File.expand_path` and `__dir__`' do
-    expect_offense(<<~RUBY)
-      require File.expand_path('../lib/rubocop', __dir__)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'registers an offense when using `require` with `File.dirname` and `__FILE__`' do
-    expect_offense(<<~RUBY)
-      require File.dirname(__FILE__) + '/../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'registers an offense when using `require` with `File.dirname` and `__dir__`' do
-    expect_offense(<<~RUBY)
-      require File.dirname(__dir__) + '/../lib/rubocop'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-    RUBY
-  end
-
-  it 'does not register an offense when using `require` with absoulte path to file' do
-    expect_no_offenses(<<~RUBY)
-      require 'file'
-    RUBY
-  end
-
-  it 'does not register an offense when using `require_relative` with absoulte path to file' do
-    expect_no_offenses(<<~RUBY)
-      require_relative 'file'
-    RUBY
-  end
-
-  it 'does not register an offense when using `require` with absolute path to spec dir' do
-    expect_no_offenses(<<~RUBY)
-      require 'spec/rubocop/file'
-    RUBY
-  end
-
-  it 'does not register an offense when using `require_relative` with absolute path to spec dir' do
-    expect_no_offenses(<<~RUBY)
-      require_relative 'spec/rubocop/file'
-    RUBY
-  end
-
-  it 'does not register an offense when using `require` with relative path to !lib' do
-    expect_no_offenses(<<~RUBY)
-      require '../spec/rubocop/file'
-    RUBY
-  end
-
-  it 'does not register an offense when using `require_relative` with relative path to !lib' do
-    expect_no_offenses(<<~RUBY)
-      require_relative '../spec/rubocop/file'
-    RUBY
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        #{source}
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
+
+  it 'registers an offense when using `require` with relative path to lib/whatever' do
+    expect_offense(<<~RUBY)
+      require '../lib/whatever'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with relative path to lib/whatever/file' do
+    expect_offense(<<~RUBY)
+      require '../lib/whatever/file'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with relative path to lib/*' do
+    expect_offense(<<~RUBY)
+      require '../lib/*'
+      ^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'does not register an offense when using `require` with absoulte path to lib' do
+    expect_no_offenses(<<~RUBY)
+      require 'whatever/file'
+    RUBY
+  end
+
+  it 'does not register an offense when using `require` with relative path to something else' do
+    expect_no_offenses(<<~RUBY)
+      require '../spec/whatever/file'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -1,29 +1,16 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
-
+RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib, :config do
   let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
 
   let(:project_root) { RuboCop::ConfigLoader.project_root }
-
-  let(:processed_source) { parse_source(source) }
-
-  before do
-    expect(RuboCop::ConfigLoader).to receive(:project_root).and_return('/some').at_least(:once)
-    allow(processed_source.buffer)
-      .to receive(:name).and_return(filename)
-    _investigate(cop, processed_source)
-  end
 
   context 'when `require_relative` call lies outside spec/' do
     let(:filename) { "#{project_root}/spec/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo.rb"' }
 
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, filename)
         #{source}
         #{'^' * source.length} #{message}
       RUBY
@@ -35,7 +22,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     let(:source) { 'require_relative "../../../lib/bar"' }
 
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, filename)
         #{source}
         #{'^' * source.length} #{message}
       RUBY
@@ -50,7 +37,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     RUBY
 
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, filename)
         #{source}
         #{'^' * 37} #{message}
       RUBY
@@ -65,7 +52,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     RUBY
 
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, filename)
         #{source}
         #{'^' * 29} #{message}
       RUBY
@@ -77,7 +64,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     let(:source) { 'require_relative "../lib/foo"' }
 
     it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, filename)
         #{source}
       RUBY
     end
@@ -88,7 +75,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     let(:source) { 'require_relative "../bar"' }
 
     it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, filename)
         #{source}
       RUBY
     end
@@ -99,7 +86,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     let(:source) { 'require_relative "spec/rubocop/qux.rb"' }
 
     it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, filename)
         #{source}
       RUBY
     end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -7,18 +7,19 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
 
   let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
 
-  let(:root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigLoader.project_root }
 
   let(:processed_source) { parse_source(source) }
 
   before do
+    expect(RuboCop::ConfigLoader).to receive(:project_root).and_return('/some').at_least(:once)
     allow(processed_source.buffer)
       .to receive(:name).and_return(filename)
     _investigate(cop, processed_source)
   end
 
   context 'when `require_relative` call lies outside spec/' do
-    let(:filename) { "#{root}/spec/foo_spec.rb" }
+    let(:filename) { "#{project_root}/spec/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo.rb"' }
 
     it 'registers an offense' do
@@ -30,7 +31,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when `require_relative` call with nested path lies outside test/' do
-    let(:filename) { "#{root}/test/rubocop/cop/bar_spec.rb" }
+    let(:filename) { "#{project_root}/test/rubocop/cop/bar_spec.rb" }
     let(:source) { 'require_relative "../../../lib/bar"' }
 
     it 'registers an offense' do
@@ -42,7 +43,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when one `require_relative` call lies outside specs/' do
-    let(:filename) { "#{root}/specs/baz_spec.rb" }
+    let(:filename) { "#{project_root}/specs/baz_spec.rb" }
     let(:source) { <<~RUBY.chomp }
       require_relative 'spec_helper'
       require_relative '../lib/rubocop/baz'
@@ -57,7 +58,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when `require_relative` call with `unshift` lies outside tests/' do
-    let(:filename) { "#{root}/tests/qux_spec.rb" }
+    let(:filename) { "#{project_root}/tests/qux_spec.rb" }
     let(:source) { <<~RUBY.chomp }
       $:.unshift('../lib')
       require_relative "../lib/qux"
@@ -72,7 +73,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call to `lib` lies inside spec/' do
-    let(:filename) { "#{root}/spec/rubocop/cop/foo_spec.rb" }
+    let(:filename) { "#{project_root}/spec/rubocop/cop/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo"' }
 
     it 'does not register an offense' do
@@ -83,7 +84,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call lies inside tests/' do
-    let(:filename) { "#{root}/tests/rubocop/cop/bar_spec.rb" }
+    let(:filename) { "#{project_root}/tests/rubocop/cop/bar_spec.rb" }
     let(:source) { 'require_relative "../bar"' }
 
     it 'does not register an offense' do
@@ -94,7 +95,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call lies inside test/' do
-    let(:filename) { "#{root}/test/qux_spec.rb" }
+    let(:filename) { "#{project_root}/test/qux_spec.rb" }
     let(:source) { 'require_relative "spec/rubocop/qux.rb"' }
 
     it 'does not register an offense' do

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     end
   end
 
-  context 'when `require_relative` call with nested path lies outside spec/' do
-    let(:filename) { '/some/spec/rubocop/cop/foo_spec.rb' }
-    let(:source) { 'require_relative "../../../lib/foo.rb"' }
+  context 'when `require_relative` call with nested path lies outside test/' do
+    let(:filename) { '/some/test/rubocop/cop/bar_spec.rb' }
+    let(:source) { 'require_relative "../../../lib/bar"' }
 
     it 'registers an offense' do
       expect_offense(<<~RUBY)
@@ -39,39 +39,39 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     end
   end
 
-  context 'when one `require_relative` call lies outside spec/' do
-    let(:filename) { '/some/spec/foo_spec.rb' }
+  context 'when one `require_relative` call lies outside specs/' do
+    let(:filename) { '/some/specs/baz_spec.rb' }
     let(:source) { <<~RUBY.chomp }
       require_relative 'spec_helper'
-      require_relative '../lib/rubocop/file'
+      require_relative '../lib/rubocop/baz'
     RUBY
 
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         #{source}
-        #{'^' * 38} #{message}
+        #{'^' * 37} #{message}
       RUBY
     end
   end
 
-  context 'when `require_relative` call with `unshift` lies outside spec/' do
-    let(:filename) { '/some/spec/foo_spec.rb' }
+  context 'when `require_relative` call with `unshift` lies outside tests/' do
+    let(:filename) { '/some/tests/qux_spec.rb' }
     let(:source) { <<~RUBY.chomp }
       $:.unshift('../lib')
-      require_relative "../lib/file"
+      require_relative "../lib/qux"
     RUBY
 
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         #{source}
-        #{'^' * 30} #{message}
+        #{'^' * 29} #{message}
       RUBY
     end
   end
 
   context 'when the `require_relative` call to `lib` lies inside spec/' do
-    let(:filename) { '/some/specs/rubocop/cop/foo_spec.rb' }
-    let(:source) { 'require_relative "../lib/foo.rb"' }
+    let(:filename) { '/some/spec/rubocop/cop/foo_spec.rb' }
+    let(:source) { 'require_relative "../lib/foo"' }
 
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
@@ -80,9 +80,9 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     end
   end
 
-  context 'when the `require_relative` call lies inside spec/' do
-    let(:filename) { '/some/specs/rubocop/cop/foo_spec.rb' }
-    let(:source) { 'require_relative "../foo.rb"' }
+  context 'when the `require_relative` call lies inside tests/' do
+    let(:filename) { '/some/tests/rubocop/cop/bar_spec.rb' }
+    let(:source) { 'require_relative "../bar"' }
 
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
@@ -91,9 +91,9 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     end
   end
 
-  context 'when the `require_relative` call lies inside spec/' do
-    let(:filename) { '/some/specs/foo_spec.rb' }
-    let(:source) { 'require_relative "spec/rubocop/bar"' }
+  context 'when the `require_relative` call lies inside test/' do
+    let(:filename) { '/some/test/qux_spec.rb' }
+    let(:source) { 'require_relative "spec/rubocop/qux.rb"' }
 
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -7,36 +7,87 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
 
   let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
 
-  it 'registers an offense when using `require` with relative path to lib/whatever' do
+  let(:path) { './../..' }
+
+  it 'registers an offense when using `require` with relative path to rubocop' do
     expect_offense(<<~RUBY)
-      require '../lib/whatever'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      require '../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
-  it 'registers an offense when using `require` with relative path to lib/whatever/file' do
+  it 'registers an offense when using `require` with relative path to rubocop/file' do
     expect_offense(<<~RUBY)
-      require '../lib/whatever/file'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      require '../lib/rubocop/file'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
-  it 'registers an offense when using `require` with relative path to lib/*' do
+  it 'registers an offense when using `require` with (more) relative path to rubocop' do
     expect_offense(<<~RUBY)
-      require '../lib/*'
-      ^^^^^^^^^^^^^^^^^^ #{message}
+      require '../../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
-  it 'does not register an offense when using `require` with absoulte path to lib' do
+  it 'registers an offense when using `unshift` and `require` with relative path to file.rb' do
+    expect_offense(<<~RUBY)
+      $:.unshift('../lib')
+      require '../lib/file.rb'
+      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with a variable and a relative path' do
+    expect_offense(<<~RUBY)
+      require "#{path}/../lib/rubocop"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with `File.expand_path` and `__FILE__`' do
+    expect_offense(<<~RUBY)
+      require File.expand_path('../lib/rubocop', __FILE__)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with `File.expand_path` and `__dir__`' do
+    expect_offense(<<~RUBY)
+      require File.expand_path('../lib/rubocop', __dir__)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with `File.dirname` and `__FILE__`' do
+    expect_offense(<<~RUBY)
+      require File.dirname(__FILE__) + '/../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with `File.dirname` and `__dir__`' do
+    expect_offense(<<~RUBY)
+      require File.dirname(__dir__) + '/../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'does not register an offense when using `require` with absoulte path to file' do
     expect_no_offenses(<<~RUBY)
-      require 'whatever/file'
+      require 'file'
     RUBY
   end
 
-  it 'does not register an offense when using `require` with relative path to something else' do
+  it 'does not register an offense when using `require` with absolute path to spec dir' do
     expect_no_offenses(<<~RUBY)
-      require '../spec/whatever/file'
+      require 'spec/rubocop/file'
+    RUBY
+  end
+
+  it 'does not register an offense when using `require` with relative path to !lib' do
+    expect_no_offenses(<<~RUBY)
+      require '../spec/rubocop/file'
     RUBY
   end
 end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
 
   let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
 
+  let(:root) { RuboCop::ConfigLoader.project_root }
+
   let(:processed_source) { parse_source(source) }
 
   before do
@@ -16,7 +18,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when `require_relative` call lies outside spec/' do
-    let(:filename) { '/some/spec/foo_spec.rb' }
+    let(:filename) { "#{root}/spec/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo.rb"' }
 
     it 'registers an offense' do
@@ -28,7 +30,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when `require_relative` call with nested path lies outside test/' do
-    let(:filename) { '/some/test/rubocop/cop/bar_spec.rb' }
+    let(:filename) { "#{root}/test/rubocop/cop/bar_spec.rb" }
     let(:source) { 'require_relative "../../../lib/bar"' }
 
     it 'registers an offense' do
@@ -40,7 +42,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when one `require_relative` call lies outside specs/' do
-    let(:filename) { '/some/specs/baz_spec.rb' }
+    let(:filename) { "#{root}/specs/baz_spec.rb" }
     let(:source) { <<~RUBY.chomp }
       require_relative 'spec_helper'
       require_relative '../lib/rubocop/baz'
@@ -55,7 +57,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when `require_relative` call with `unshift` lies outside tests/' do
-    let(:filename) { '/some/tests/qux_spec.rb' }
+    let(:filename) { "#{root}/tests/qux_spec.rb" }
     let(:source) { <<~RUBY.chomp }
       $:.unshift('../lib')
       require_relative "../lib/qux"
@@ -70,7 +72,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call to `lib` lies inside spec/' do
-    let(:filename) { '/some/spec/rubocop/cop/foo_spec.rb' }
+    let(:filename) { "#{root}/spec/rubocop/cop/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo"' }
 
     it 'does not register an offense' do
@@ -81,7 +83,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call lies inside tests/' do
-    let(:filename) { '/some/tests/rubocop/cop/bar_spec.rb' }
+    let(:filename) { "#{root}/tests/rubocop/cop/bar_spec.rb" }
     let(:source) { 'require_relative "../bar"' }
 
     it 'does not register an offense' do
@@ -92,7 +94,7 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
   end
 
   context 'when the `require_relative` call lies inside test/' do
-    let(:filename) { '/some/test/qux_spec.rb' }
+    let(:filename) { "#{root}/test/qux_spec.rb" }
     let(:source) { 'require_relative "spec/rubocop/qux.rb"' }
 
     it 'does not register an offense' do

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -16,10 +16,28 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     RUBY
   end
 
-  it 'registers an offense when using `require` with relative path to rubocop/file' do
+  it 'registers an offense when using `require_relative` with relative path to rubocop' do
     expect_offense(<<~RUBY)
+      require_relative '../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require` with relative path twice' do
+    expect_offense(<<~RUBY)
+      require '../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
       require '../lib/rubocop/file'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require_relative` with relative path twice' do
+    expect_offense(<<~RUBY)
+      require_relative '../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      require_relative '../lib/rubocop/file'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
@@ -27,6 +45,13 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     expect_offense(<<~RUBY)
       require '../../lib/rubocop'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require_relative` with (more) relative path to rubocop' do
+    expect_offense(<<~RUBY)
+      require_relative '../../lib/rubocop'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
@@ -38,10 +63,25 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     RUBY
   end
 
+  it 'registers an offense when using `unshift` and `require_relative` with relative path to file.rb' do
+    expect_offense(<<~RUBY)
+      $:.unshift('../lib')
+      require_relative '../lib/file.rb'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
   it 'registers an offense when using `require` with a variable and a relative path' do
     expect_offense(<<~RUBY)
       require "#{path}/../lib/rubocop"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+    RUBY
+  end
+
+  it 'registers an offense when using `require_relative` with a variable and a relative path' do
+    expect_offense(<<~RUBY)
+      require_relative "#{path}/../lib/rubocop"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
   end
 
@@ -79,15 +119,33 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib do
     RUBY
   end
 
+  it 'does not register an offense when using `require_relative` with absoulte path to file' do
+    expect_no_offenses(<<~RUBY)
+      require_relative 'file'
+    RUBY
+  end
+
   it 'does not register an offense when using `require` with absolute path to spec dir' do
     expect_no_offenses(<<~RUBY)
       require 'spec/rubocop/file'
     RUBY
   end
 
+  it 'does not register an offense when using `require_relative` with absolute path to spec dir' do
+    expect_no_offenses(<<~RUBY)
+      require_relative 'spec/rubocop/file'
+    RUBY
+  end
+
   it 'does not register an offense when using `require` with relative path to !lib' do
     expect_no_offenses(<<~RUBY)
       require '../spec/rubocop/file'
+    RUBY
+  end
+
+  it 'does not register an offense when using `require_relative` with relative path to !lib' do
+    expect_no_offenses(<<~RUBY)
+      require_relative '../spec/rubocop/file'
     RUBY
   end
 end


### PR DESCRIPTION
**TODO**:
- [x] document stuff.
- [x] ~fix regex to match proper calls.~   use `File.expand_path` to check if the expanded path lies inside the `lib` directory or not.
- [x] ~find a way to only check calls in the spec(s)/test(s) dir.~

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>