### PR TITLE
Don't flag offenses when calls are made from lib/

### DIFF
--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib, :config do
     end
   end
 
+  context 'when `require_relative` call is made from inside lib/' do
+    let(:filename) { "#{project_root}/lib/foo.rb" }
+    let(:source) { 'require_relative "../lib/bar"' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, filename)
+        #{source}
+      RUBY
+    end
+  end
+
+  context 'when `require_relative` calls are made from inside lib/' do
+    let(:filename) { "#{project_root}/lib/foo/bar.rb" }
+    let(:source) { <<~RUBY.chomp }
+      require_relative '../baz'
+      require_relative 'foo/qux'
+    RUBY
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, filename)
+        #{source}
+      RUBY
+    end
+  end
+
   context 'when the `require_relative` call to `lib` lies inside spec/' do
     let(:filename) { "#{project_root}/spec/rubocop/cop/foo_spec.rb" }
     let(:source) { 'require_relative "../lib/foo"' }


### PR DESCRIPTION
At the moment, we are flagging *all* the `require_relative`
calls unless specified to behave differently via .rubocop.yml.

This means that this cop flags an offense as soon as it finds
a `require_relative` call anywhere. But it shouldn't flag
those as offenses if they're being used in lib/ and are
requiring files inside lib/ itself.

This is a false-positive.

Fixes: #8 
