### PR TITLE
RelativeRequireToLib cop shouldn't check gemspec files

### DIFF
--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -67,7 +67,7 @@ module RuboCop # :nodoc:
         # It flags an offense if the `require_relative` call is made
         # from anywhere except the "lib" directory.
         def falls_in_lib?(str)
-          target_falls_in_lib?(str) && !inspected_file_falls_in_lib?
+          target_falls_in_lib?(str) && !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
         end
 
         # This method determines if the `require_relative` call is made
@@ -76,10 +76,14 @@ module RuboCop # :nodoc:
           File.expand_path(str, @file_directory).start_with?("#{root_dir}/lib")
         end
 
-        # This method determines if that call is made *from* the "lib"
-        # directory.
+        # This method determines if that call is made *from* the "lib" directory.
         def inspected_file_falls_in_lib?
           @file_path.start_with?("#{root_dir}/lib")
+        end
+
+        # This method determines if that call is made *from* the "gemspec" file.
+        def inspected_file_is_gemspec?
+          @file_path.end_with?('gemspec')
         end
       end
     end

--- a/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/relative_require_to_lib_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib, :config do
     end
   end
 
+  context 'when `require_relative` call is made from the gemspec file' do
+    let(:filename) { "#{project_root}/foo.gemspec" }
+    let(:source) { 'require_relative "lib/foo/version"' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, filename)
+        #{source}
+      RUBY
+    end
+  end
+
   context 'when `require_relative` calls are made from inside lib/' do
     let(:filename) { "#{project_root}/lib/foo/bar.rb" }
     let(:source) { <<~RUBY.chomp }


### PR DESCRIPTION
Originally discovered in mvz/rake-manifest@0acb6bb, where
the RelativeRequireToLib was flagging an offense in the
gemspec file. It shouldn't.

This is yet another false-positive.

Fixes: #11