### PR TITLE
Re-structure the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ which is a Ruby static code analyzer (a.k.a. linter) and code formatter.
 
 It helps enforcing some of the guidelines that are expected of upstream
 maintainers so that the downstream can build their packages in a clean
-environment without any problems.  
-Some of the other basic guidelines can be found
-[here](https://wiki.debian.org/Teams/Ruby/RubyExtras/UpstreamDevelopers).
+environment without any problems.
+
+## Documentation
+
+A detailed documentation, explaining what this extension is doing and the
+reasoning behind it, can be found here: [packaging-style-guide](https://github.com/utkarsh2102/packaging-style-guide).
+
+In case anything is not clear, please feel free to raise an issue, asking
+for more explanation!
 
 ## Installation
 

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -12,9 +12,12 @@
 | 0.1
 |===
 
-This cop is used to identify the usage of `git ls-files`
+This cop flags the usage of `git ls-files` in gemspec
 and suggests to use a plain Ruby alternative, like `Dir`,
-`Dir.glob` or `Rake::FileList` instead.
+`Dir.glob`, or `Rake::FileList` instead.
+
+More information about the GemspecGit cop can be found here:
+https://github.com/utkarsh2102/packaging-style-guide#gemspec-git
 
 === Examples
 
@@ -22,21 +25,8 @@ and suggests to use a plain Ruby alternative, like `Dir`,
 ----
 # bad
 Gem::Specification.new do |spec|
-  spec.files = `git ls-files`.split('\n')
-end
-
-# bad
-Gem::Specification.new do |spec|
-  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-end
-
-# bad
-Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split('\n')
-  spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
-  spec.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
+  spec.test_files    = `git ls-files -- spec`.split('\n')
 end
 
 # good
@@ -45,9 +35,23 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*']
 end
 
+# bad
+Gem::Specification.new do |spec|
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+end
+
 # good
 Gem::Specification.new do |spec|
   spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.files         = `git ls-files -- lib/`.split('\n')
+  spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
+  spec.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
 end
 
 # good
@@ -70,9 +74,12 @@ end
 | -
 |===
 
-This cop is used to identify the `require_relative` calls,
-mapping to the "lib" directory and suggests to use `require`
-instead.
+This cop flags the `require_relative` calls, from anywhere
+mapping to the "lib" directory, except originating from lib/ or
+the gemspec file, and suggests to use `require` instead.
+
+More information about the RelativeRequireToLib cop can be found here:
+https://github.com/utkarsh2102/packaging-style-guide#require-relative-to-lib
 
 === Examples
 
@@ -81,16 +88,16 @@ instead.
 # bad
 require_relative 'lib/foo.rb'
 
-# bad
-require_relative '../../lib/foo/bar'
-
 # good
 require 'foo.rb'
+
+# bad
+require_relative '../../lib/foo/bar'
 
 # good
 require 'foo/bar'
 
 # good
 require_relative 'spec_helper'
-require_relative 'foo/bar'
+require_relative 'spec/foo/bar'
 ----

--- a/lib/rubocop/cop/packaging/gemspec_git.rb
+++ b/lib/rubocop/cop/packaging/gemspec_git.rb
@@ -3,29 +3,19 @@
 module RuboCop # :nodoc:
   module Cop # :nodoc:
     module Packaging # :nodoc:
-      # This cop is used to identify the usage of `git ls-files`
+      # This cop flags the usage of `git ls-files` in gemspec
       # and suggests to use a plain Ruby alternative, like `Dir`,
-      # `Dir.glob` or `Rake::FileList` instead.
+      # `Dir.glob`, or `Rake::FileList` instead.
+      #
+      # More information about the GemspecGit cop can be found here:
+      # https://github.com/utkarsh2102/packaging-style-guide#gemspec-git
       #
       # @example
       #
       #   # bad
       #   Gem::Specification.new do |spec|
-      #     spec.files = `git ls-files`.split('\n')
-      #   end
-      #
-      #   # bad
-      #   Gem::Specification.new do |spec|
-      #     spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-      #       `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
-      #     end
-      #   end
-      #
-      #   # bad
-      #   Gem::Specification.new do |spec|
       #     spec.files         = `git ls-files`.split('\n')
-      #     spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
-      #     spec.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
+      #     spec.test_files    = `git ls-files -- spec`.split('\n')
       #   end
       #
       #   # good
@@ -34,9 +24,23 @@ module RuboCop # :nodoc:
       #     spec.test_files    = Dir['spec/**/*']
       #   end
       #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.files = Dir.chdir(File.expand_path(__dir__)) do
+      #       `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+      #     end
+      #   end
+      #
       #   # good
       #   Gem::Specification.new do |spec|
       #     spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+      #   end
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.files         = `git ls-files -- lib/`.split('\n')
+      #     spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
+      #     spec.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
       #   end
       #
       #   # good

--- a/lib/rubocop/cop/packaging/relative_require_to_lib.rb
+++ b/lib/rubocop/cop/packaging/relative_require_to_lib.rb
@@ -3,27 +3,30 @@
 module RuboCop # :nodoc:
   module Cop # :nodoc:
     module Packaging # :nodoc:
-      # This cop is used to identify the `require_relative` calls,
-      # mapping to the "lib" directory and suggests to use `require`
-      # instead.
+      # This cop flags the `require_relative` calls, from anywhere
+      # mapping to the "lib" directory, except originating from lib/ or
+      # the gemspec file, and suggests to use `require` instead.
+      #
+      # More information about the RelativeRequireToLib cop can be found here:
+      # https://github.com/utkarsh2102/packaging-style-guide#require-relative-to-lib
       #
       # @example
       #
       #   # bad
       #   require_relative 'lib/foo.rb'
       #
-      #   # bad
-      #   require_relative '../../lib/foo/bar'
-      #
       #   # good
       #   require 'foo.rb'
+      #
+      #   # bad
+      #   require_relative '../../lib/foo/bar'
       #
       #   # good
       #   require 'foo/bar'
       #
       #   # good
       #   require_relative 'spec_helper'
-      #   require_relative 'foo/bar'
+      #   require_relative 'spec/foo/bar'
       #
       class RelativeRequireToLib < Base
         # This is the message that will be displayed when RuboCop finds an


### PR DESCRIPTION
To summarize:

- Alternate the good and bad example.
- Point to packaging-style-guide for more information.
- Reflect the change in `docs/`.
- Add "Documentation" section.
  - Point to packaging-style-guide.

Fixes: #3 
Fixes: #9