### PR TITLE
Change cop name to RequireRelativeHardcodingLib

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,3 +10,4 @@ Packaging/RequireRelativeHardcodingLib:
   Description: 'Avoid using `require_relative` with relative path to lib.'
   Enabled: true
   VersionAdded: '0.2'
+  VersionChanged: '0.3'

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@ Packaging/GemspecGit:
   VersionAdded: '0.1'
   VersionChanged: '0.1'
 
-Packaging/RelativeRequireToLib:
+Packaging/RequireRelativeHardcodingLib:
   Description: 'Avoid using `require_relative` with relative path to lib.'
   Enabled: true
   VersionAdded: '0.2'

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -3,6 +3,6 @@
 === Department xref:cops_packaging.adoc[Packaging]
 
 * xref:cops_packaging.adoc#packaginggemspecgit[Packaging/GemspecGit]
-* xref:cops_packaging.adoc#packagingrelativerequiretolib[Packaging/RelativeRequireToLib]
+* xref:cops_packaging.adoc#packagingrequirerelativehardcodinglib[Packaging/RequireRelativeHardcodingLib]
 
 // END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
 end
 ----
 
-== Packaging/RelativeRequireToLib
+== Packaging/RequireRelativeHardcodingLib
 
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -78,8 +78,8 @@ This cop flags the `require_relative` calls, from anywhere
 mapping to the "lib" directory, except originating from lib/ or
 the gemspec file, and suggests to use `require` instead.
 
-More information about the RelativeRequireToLib cop can be found here:
-https://github.com/utkarsh2102/packaging-style-guide#require-relative-to-lib
+More information about the RequireRelativeHardcodingLib cop can be found here:
+https://github.com/utkarsh2102/packaging-style-guide#require-relative-hardcoding-lib
 
 === Examples
 

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -71,7 +71,7 @@ end
 | Yes
 | No
 | 0.2
-| -
+| 0.3
 |===
 
 This cop flags the `require_relative` calls, from anywhere

--- a/lib/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
+++ b/lib/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
@@ -7,8 +7,8 @@ module RuboCop # :nodoc:
       # mapping to the "lib" directory, except originating from lib/ or
       # the gemspec file, and suggests to use `require` instead.
       #
-      # More information about the RelativeRequireToLib cop can be found here:
-      # https://github.com/utkarsh2102/packaging-style-guide#require-relative-to-lib
+      # More information about the RequireRelativeHardcodingLib cop can be found here:
+      # https://github.com/utkarsh2102/packaging-style-guide#require-relative-hardcoding-lib
       #
       # @example
       #
@@ -28,7 +28,7 @@ module RuboCop # :nodoc:
       #   require_relative 'spec_helper'
       #   require_relative 'spec/foo/bar'
       #
-      class RelativeRequireToLib < Base
+      class RequireRelativeHardcodingLib < Base
         # This is the message that will be displayed when RuboCop finds an
         # offense of using `require_relative` with relative path to lib.
         MSG = 'Avoid using `require_relative` with relative path to lib. ' \

--- a/lib/rubocop/cop/packaging_cops.rb
+++ b/lib/rubocop/cop/packaging_cops.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'packaging/gemspec_git'
-require_relative 'packaging/relative_require_to_lib'
+require_relative 'packaging/require_relative_hardcoding_lib'

--- a/spec/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
+++ b/spec/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Packaging::RelativeRequireToLib, :config do
-  let(:message) { RuboCop::Cop::Packaging::RelativeRequireToLib::MSG }
+RSpec.describe RuboCop::Cop::Packaging::RequireRelativeHardcodingLib, :config do
+  let(:message) { RuboCop::Cop::Packaging::RequireRelativeHardcodingLib::MSG }
 
   let(:project_root) { RuboCop::ConfigLoader.project_root }
 


### PR DESCRIPTION
The cop name, `RelativeRequireToLib`, wasn't generic and
wasn't clear enough by the name as to what this cop is
trying to do. Therefore, renaming to `RequireRelativeHardcodingLib`.

Also, add `VersionChanged` fields, pointing to `0.3`, for
`RequireRelativeHardcodingLib` cop as there'll soon
be a v0.3.0.

And finally, reflect all this in the docs as well as packaging-style-guide.