### PR TITLE
Support autocorrect for BundlerSetupInTests cop

### DIFF
--- a/lib/rubocop/cop/packaging/bundler_setup_in_tests.rb
+++ b/lib/rubocop/cop/packaging/bundler_setup_in_tests.rb
@@ -19,6 +19,8 @@ module RuboCop # :nodoc:
       #
       class BundlerSetupInTests < Base
         include RuboCop::Packaging::LibHelperModule
+        include RangeHelp
+        extend AutoCorrector
 
         # This is the message that will be displayed when RuboCop::Packaging finds
         # an offense of using `require "bundler/setup"` in the tests directory.
@@ -45,7 +47,17 @@ module RuboCop # :nodoc:
         def on_send(node)
           return unless bundler_setup?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        # Called from on_send, this method helps to autocorrect
+        # the offenses flagged by this cop.
+        def autocorrect(corrector, node)
+          range = range_by_whole_lines(node.source_range, include_final_newline: true)
+
+          corrector.remove(range)
         end
 
         # This method is called from inside `#def_node_matcher`.

--- a/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
+++ b/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
         #{source}
         #{"^" * source.length} #{message}
       RUBY
+
+      expect_correction(<<~RUBY)
+      RUBY
     end
   end
 
@@ -25,6 +28,9 @@ RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
       expect_offense(<<~RUBY, filename)
         #{source}
         #{"^" * source.length} #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
       RUBY
     end
   end


### PR DESCRIPTION
Eeee, the autocorrect is here! \o/
With this, you can just run rubocop -A to automatically
fix the offenses flagged by this cop.

This has been tested (besides the tests themselves :P)
and should be good to go!