### PR TITLE
Support autocorrect for RequireWithRelativePath cop

### DIFF
--- a/lib/rubocop/cop/packaging/require_with_relative_path.rb
+++ b/lib/rubocop/cop/packaging/require_with_relative_path.rb
@@ -73,8 +73,7 @@ module RuboCop # :nodoc:
         # Called from on_send, this method helps to replace
         # the "bad" require call with the "good" one.
         def good_require_call
-          bad_part = @str.match(%r{.*/lib/}).to_s
-          good_call = @str.delete_prefix(bad_part)
+          good_call = @str.sub(%r{^.*/lib/}, "")
           %(require "#{good_call}")
         end
 

--- a/spec/rubocop/cop/packaging/require_with_relative_path_spec.rb
+++ b/spec/rubocop/cop/packaging/require_with_relative_path_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
         #{source}
         #{"^" * source.length} #{message}
       RUBY
+
+      expect_correction(<<~RUBY)
+        require "foo.rb"
+      RUBY
     end
   end
 
@@ -29,6 +33,11 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
         #{source}
         #{"^" * 27} #{message}
       RUBY
+
+      expect_correction(<<~RUBY)
+        $:.unshift('../../lib')
+        require "foo/bar"
+      RUBY
     end
   end
 
@@ -40,6 +49,10 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
       expect_offense(<<~RUBY, filename)
         #{source}
         #{"^" * source.length} #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require "foo"
       RUBY
     end
   end
@@ -53,6 +66,10 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
         #{source}
         #{"^" * source.length} #{message}
       RUBY
+
+      expect_correction(<<~RUBY)
+        require "foo/bar/baz/qux"
+      RUBY
     end
   end
 
@@ -65,6 +82,10 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
         #{source}
         #{"^" * source.length} #{message}
       RUBY
+
+      expect_correction(<<~RUBY)
+        require "baz/qux"
+      RUBY
     end
   end
 
@@ -76,6 +97,10 @@ RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
       expect_offense(<<~RUBY, filename)
         #{source}
         #{"^" * source.length} #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require "foo"
       RUBY
     end
   end


### PR DESCRIPTION
Eeee, the autocorrect is here! \o/
With this, you can just run rubocop -A to automatically
fix the offenses flagged by this cop.

Hm, whilst this is good to go "initially" with, this
might produce some false-positives. So I am going
to keep this open for sometime and experiment more
with this.

NOTE: the autocorrect uses regex to fix the offenses
so naturally, I'd expect some things here and there 😫 