### PR TITLE
RequireWithRelativePath shouldn't check files inside lib/

### DIFF
--- a/lib/rubocop/cop/packaging/require_with_relative_path.rb
+++ b/lib/rubocop/cop/packaging/require_with_relative_path.rb
@@ -85,7 +85,7 @@ module RuboCop # :nodoc:
         # And then determines if that call is made to "lib/".
         def falls_in_lib_with_file_dirname_plus_str?(str)
           str.prepend(".")
-          target_falls_in_lib?(str)
+          target_falls_in_lib?(str) && !inspected_file_falls_in_lib?
         end
       end
     end


### PR DESCRIPTION
Checking files inside the lib directory doesn't help us really.
What problematic to us is using the calls cross-lib.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>