### PR TITLE
Refactor RequireRelativeHardcodingLib & RequireWithRelativePath cops

### DIFF
--- a/lib/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
+++ b/lib/rubocop/cop/packaging/require_relative_hardcoding_lib.rb
@@ -74,7 +74,7 @@ module RuboCop # :nodoc:
         # from anywhere except the "lib" directory.
         def falls_in_lib?(str)
           @str = str
-          target_falls_in_lib?(str) && !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
+          target_falls_in_lib?(str) && inspected_file_is_not_in_lib_or_gemspec?
         end
       end
     end

--- a/lib/rubocop/cop/packaging/require_with_relative_path.rb
+++ b/lib/rubocop/cop/packaging/require_with_relative_path.rb
@@ -71,21 +71,21 @@ module RuboCop # :nodoc:
         # It flags an offense if the `require` call is made from
         # anywhere except the "lib" directory.
         def falls_in_lib?(str)
-          target_falls_in_lib?(str) && !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
+          target_falls_in_lib?(str) && inspected_file_is_not_in_lib_or_gemspec?
         end
 
         # This method is called from inside `#def_node_matcher`.
         # It flags an offense if the `require` call (using the __FILE__
         # arguement) is made from anywhere except the "lib" directory.
         def falls_in_lib_using_file?(str)
-          target_falls_in_lib_using_file?(str) && !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
+          target_falls_in_lib_using_file?(str) && inspected_file_is_not_in_lib_or_gemspec?
         end
 
         # This method preprends a "." to the string that starts with "/".
         # And then determines if that call is made to "lib/".
         def falls_in_lib_with_file_dirname_plus_str?(str)
           str.prepend(".")
-          target_falls_in_lib?(str) && !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
+          target_falls_in_lib?(str) && inspected_file_is_not_in_lib_or_gemspec?
         end
       end
     end

--- a/lib/rubocop/packaging/lib_helper_module.rb
+++ b/lib/rubocop/packaging/lib_helper_module.rb
@@ -30,6 +30,12 @@ module RuboCop # :nodoc:
       def inspected_file_is_gemspec?
         @file_path.end_with?("gemspec")
       end
+
+      # This method determines if the inspected file is not in lib/ or
+      # isn't a gemspec file.
+      def inspected_file_is_not_in_lib_or_gemspec?
+        !inspected_file_falls_in_lib? && !inspected_file_is_gemspec?
+      end
     end
   end
 end


### PR DESCRIPTION
Extract `inspected_file_falls_in_lib?` & `inspected_file_is_gemspec?`
methods to a separate method and use it in the cops instead of
using the former two methods each time.

Remove duplicated stuff, FTW!

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>