### PR TITLE
Rename RequireRelativeHardcodingLib to RequireHardcodingLib

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -12,14 +12,14 @@ Packaging/GemspecGit:
   VersionAdded: '0.1'
   VersionChanged: '0.1'
 
+Packaging/RequireHardcodingLib:
+  Description: 'Avoid using `require` with relative path to lib.'
+  Enabled: true
+  VersionAdded: '0.4'
+  VersionChanged: '0.5'
+
 Packaging/RequireRelativeHardcodingLib:
   Description: 'Avoid using `require_relative` with relative path to lib.'
   Enabled: true
   VersionAdded: '0.2'
-  VersionChanged: '0.5'
-
-Packaging/RequireWithRelativePath:
-  Description: 'Avoid using `require` with relative path to lib.'
-  Enabled: true
-  VersionAdded: '0.4'
   VersionChanged: '0.5'

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -15,7 +15,7 @@ projects.
 
 * xref:cops_packaging.adoc#packagingbundlersetupintests[Packaging/BundlerSetupInTests]
 * xref:cops_packaging.adoc#packaginggemspecgit[Packaging/GemspecGit]
+* xref:cops_packaging.adoc#packagingrequirehardcodinglib[Packaging/RequireHardcodingLib]
 * xref:cops_packaging.adoc#packagingrequirerelativehardcodinglib[Packaging/RequireRelativeHardcodingLib]
-* xref:cops_packaging.adoc#packagingrequirewithrelativepath[Packaging/RequireWithRelativePath]
 
 // END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -125,6 +125,50 @@ Gem::Specification.new do |spec|
 end
 ----
 
+== Packaging/RequireHardcodingLib
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| Yes
+| 0.4
+| 0.5
+|===
+
+This cop flags the `require` calls, from anywhere mapping to
+the "lib" directory, except originating from lib/.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+require "../lib/foo/bar"
+
+# good
+require "foo/bar"
+
+# bad
+require File.expand_path("../../lib/foo", __FILE__)
+
+# good
+require "foo"
+
+# bad
+require File.expand_path("../../../lib/foo/bar/baz/qux", __dir__)
+
+# good
+require "foo/bar/baz/qux"
+
+# bad
+require File.dirname(__FILE__) + "/../../lib/baz/qux"
+
+# good
+require "baz/qux"
+----
+
 == Packaging/RequireRelativeHardcodingLib
 
 |===
@@ -177,48 +221,4 @@ require "foo/bar"
 # good
 require_relative "spec_helper"
 require_relative "spec/foo/bar"
-----
-
-== Packaging/RequireWithRelativePath
-
-|===
-| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
-
-| Enabled
-| Yes
-| Yes
-| 0.4
-| 0.5
-|===
-
-This cop flags the `require` calls, from anywhere mapping to
-the "lib" directory, except originating from lib/.
-
-=== Examples
-
-[source,ruby]
-----
-# bad
-require "../lib/foo/bar"
-
-# good
-require "foo/bar"
-
-# bad
-require File.expand_path("../../lib/foo", __FILE__)
-
-# good
-require "foo"
-
-# bad
-require File.expand_path("../../../lib/foo/bar/baz/qux", __dir__)
-
-# good
-require "foo/bar/baz/qux"
-
-# bad
-require File.dirname(__FILE__) + "/../../lib/baz/qux"
-
-# good
-require "baz/qux"
 ----

--- a/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
+++ b/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
@@ -34,7 +34,7 @@ module RuboCop # :nodoc:
       #   # good
       #   require "baz/qux"
       #
-      class RequireWithRelativePath < Base
+      class RequireHardcodingLib < Base
         include RuboCop::Packaging::LibHelperModule
         extend AutoCorrector
 

--- a/lib/rubocop/cop/packaging_cops.rb
+++ b/lib/rubocop/cop/packaging_cops.rb
@@ -2,5 +2,5 @@
 
 require_relative "packaging/bundler_setup_in_tests"
 require_relative "packaging/gemspec_git"
+require_relative "packaging/require_hardcoding_lib"
 require_relative "packaging/require_relative_hardcoding_lib"
-require_relative "packaging/require_with_relative_path"

--- a/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Packaging::RequireWithRelativePath, :config do
-  let(:message) { RuboCop::Cop::Packaging::RequireWithRelativePath::MSG }
+RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
+  let(:message) { RuboCop::Cop::Packaging::RequireHardcodingLib::MSG }
 
   let(:project_root) { RuboCop::ConfigLoader.project_root }
 


### PR DESCRIPTION
The cop name, RelativeWithRelativePath, wasn't generic
and wasn't clear enough by the name as to what this
cop is trying to do.

Therefore, renaming to RequireHardcodingLib.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>