### PR TITLE
Add AST pattern to catch interpolated require calls

### DIFF
--- a/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
+++ b/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
@@ -46,7 +46,8 @@ module RuboCop # :nodoc:
           {(send nil? :require (str #falls_in_lib?))
            (send nil? :require (send (const nil? :File) :expand_path (str #falls_in_lib?) (send nil? :__dir__)))
            (send nil? :require (send (const nil? :File) :expand_path (str #falls_in_lib_using_file?) (str _)))
-           (send nil? :require (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #falls_in_lib_with_file_dirname_plus_str?)))}
+           (send nil? :require (send (send (const nil? :File) :dirname {(str _) (send nil? _)}) :+ (str #falls_in_lib_with_file_dirname_plus_str?)))
+           (send nil? :require (dstr (begin (send (const nil? :File) :dirname {(str _) (send nil? _)})) (str #falls_in_lib_with_file_dirname_plus_str?)))}
         PATTERN
 
         # Extended from the Base class.

--- a/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
@@ -89,9 +89,41 @@ RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
     end
   end
 
+  context "when `require` call uses File#dirname method with __FILE__ with interpolation" do
+    let(:filename) { "#{project_root}/specs/baz/qux_spec.rb" }
+    let(:source) { 'require "#{File.dirname(__FILE__)}/../../lib/baz/qux"' }
+
+    it "registers an offense" do
+      expect_offense(<<~RUBY, filename)
+        #{source}
+        #{"^" * source.length} #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require "baz/qux"
+      RUBY
+    end
+  end
+
   context "when `require` call uses File#dirname method with __dir__" do
     let(:filename) { "#{project_root}/spec/foo.rb" }
     let(:source) { "require File.dirname(__dir__) + '/../lib/foo'" }
+
+    it "registers an offense" do
+      expect_offense(<<~RUBY, filename)
+        #{source}
+        #{"^" * source.length} #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require "foo"
+      RUBY
+    end
+  end
+
+  context "when `require` call uses File#dirname method with __dir__ with interpolation" do
+    let(:filename) { "#{project_root}/spec/foo.rb" }
+    let(:source) { 'require "#{File.dirname(__dir__)}/../lib/foo"' }
 
     it "registers an offense" do
       expect_offense(<<~RUBY, filename)

--- a/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
 
   context "when `require` call uses File#dirname method with __FILE__ with interpolation" do
     let(:filename) { "#{project_root}/specs/baz/qux_spec.rb" }
-    let(:source) { 'require "#{File.dirname(__FILE__)}/../../lib/baz/qux"' }
+    let(:source) { 'require "#{File.dirname(__FILE__)}/../../lib/baz/qux"' } # rubocop:disable Lint/InterpolationCheck
 
     it "registers an offense" do
       expect_offense(<<~RUBY, filename)
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
 
   context "when `require` call uses File#dirname method with __dir__ with interpolation" do
     let(:filename) { "#{project_root}/spec/foo.rb" }
-    let(:source) { 'require "#{File.dirname(__dir__)}/../lib/foo"' }
+    let(:source) { 'require "#{File.dirname(__dir__)}/../lib/foo"' } # rubocop:disable Lint/InterpolationCheck
 
     it "registers an offense" do
       expect_offense(<<~RUBY, filename)


### PR DESCRIPTION
Style/StringConcatenation's autocorrect hinders with the
existing AST pattern of RequireHardcodingLib to catch
offensive require calls. So add the interpolated AST to
catch those lines as well.

Also, add tests to check if the interpolated require calls
are correctly being caught by the RequireHardcodingLib
cop and that the autocorrect for it is working fine
as well.

And lastly, disable `Lint/InterpolationCheck` for mocked tests
since the tests are mocked and enabling them will break the tests.

Fixes: #30