### PR TITLE
Fix HTML id attribute in cops_packaging.adoc

### DIFF
--- a/docs/modules/ROOT/pages/cops_packaging.adoc
+++ b/docs/modules/ROOT/pages/cops_packaging.adoc
@@ -202,7 +202,7 @@ installed system-wide" use case.
 
 Therefore, it is still recommended to use `require_relative` with just this exception to it.
 
-=== Examples [[require-relative-hardcoding-lib-rationale]]
+=== Examples [[require-relative-hardcoding-lib-examples]]
 
 [source,ruby]
 ----


### PR DESCRIPTION
This PR fixes the following HTML id attribute in cops_packaging.adoc.

```console
% git grep require-relative-hardcoding-lib-rationale
docs/modules/ROOT/pages/cops_packaging.adoc:=== Rationale [[require-relative-hardcoding-lib-rationale]]
docs/modules/ROOT/pages/cops_packaging.adoc:=== Examples [[require-relative-hardcoding-lib-rationale]]
```

It will suppress the following warning that generates docs.rubocop.org.

```console
$ cd docs.rubocop.org
$ antora --pull antora-playbook.yml
(snip)

asciidoctor: WARNING: cops_packaging.adoc: line 205: id assigned to
section already in use: require-relative-hardcoding-lib-rationale
```