### PR TITLE
Loosen requirement of Rubocop

### DIFF
--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency   "rake", "~> 13.0"
   spec.add_development_dependency   "rspec", "~> 3.0"
   spec.add_development_dependency   "yard", "~> 0.9"
-  spec.add_runtime_dependency       "rubocop", "~> 0.89"
+  spec.add_runtime_dependency       "rubocop", ">= 0.89", "< 2.0"
 end


### PR DESCRIPTION
Rubocop 1.0 is out, we need to loosen the requirement to compatible with it