### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Naming/FileName:
   Exclude:

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["config/default.yml", "lib/**/*", "LICENSE", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.add_development_dependency   "bump", "~> 0.8"
   spec.add_development_dependency   "pry", "~> 0.13"
   spec.add_development_dependency   "rake", "~> 13.0"
   spec.add_development_dependency   "rspec", "~> 3.0"
   spec.add_development_dependency   "yard", "~> 0.9"
-  spec.add_runtime_dependency       "rubocop", ">= 0.89", "< 2.0"
+  spec.add_runtime_dependency       "rubocop", ">= 1.13", "< 2.0"
 end

--- a/spec/rubocop/packaging_spec.rb
+++ b/spec/rubocop/packaging_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe RuboCop::Packaging do
       end
     end
 
-    it "has a SupportedStyles for all EnforcedStyle " \
-      "and EnforcedStyle is valid" do
+    it "has a SupportedStyles for all EnforcedStyle and EnforcedStyle is valid" do
       errors = []
       cop_names.each do |name|
         enforced_styles = config[name]

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -25,8 +25,7 @@ task verify_cops_documentation: :generate_cops_documentation do
     # Output diff before raising error
     sh("GIT_PAGER=cat git diff docs")
 
-    warn "The docs directory is out of sync. " \
-      "Run `rake generate_cops_documentation` and commit the results."
+    warn "The docs directory is out of sync. Run `rake generate_cops_documentation` and commit the results."
     exit!
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/utkarsh2102/rubocop-packaging/commit/6972a97 and https://github.com/rubocop/rubocop/pull/9648.