### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/utkarsh2102/rubocop-packaging"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files         = Dir["config/default.yml", "lib/**/*", "LICENSE", "README.md"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Migrates CI to GitHub Actions now that Travis CI.org is inactive.

Also fixes a lint warning from Rubocop by adding an MFA requirement for gem publication.