### PR TITLE
Fix compatibility with Rubocop 1.33.0

### DIFF
--- a/lib/rubocop/packaging/lib_helper_module.rb
+++ b/lib/rubocop/packaging/lib_helper_module.rb
@@ -7,7 +7,7 @@ module RuboCop # :nodoc:
     module LibHelperModule
       # For determining the root directory of the project.
       def root_dir
-        RuboCop::ConfigLoader.project_root
+        RuboCop::ConfigFinder.project_root
       end
 
       # This method determines if the calls are made to the "lib" directory.

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency   "rake", "~> 13.0"
   spec.add_development_dependency   "rspec", "~> 3.0"
   spec.add_development_dependency   "yard", "~> 0.9"
-  spec.add_runtime_dependency       "rubocop", ">= 1.13", "< 2.0"
+  spec.add_runtime_dependency       "rubocop", ">= 1.33", "< 2.0"
 end

--- a/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
+++ b/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
         #{"^" * source.length} #{message}
       RUBY
 
-      expect_correction(<<~RUBY)
-      RUBY
+      expect_correction("")
     end
   end
 
@@ -30,8 +29,7 @@ RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
         #{"^" * source.length} #{message}
       RUBY
 
-      expect_correction(<<~RUBY)
-      RUBY
+      expect_correction("")
     end
   end
 

--- a/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
+++ b/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
   let(:message) { RuboCop::Cop::Packaging::BundlerSetupInTests::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require bundler/setup` is used in specs/" do
     let(:filename) { "#{project_root}/spec/spec_helper.rb" }

--- a/spec/rubocop/cop/packaging/gemspec_git_spec.rb
+++ b/spec/rubocop/cop/packaging/gemspec_git_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe RuboCop::Cop::Packaging::GemspecGit do
   end
 
   it "does not register an offense when the file is empty/blank" do
-    expect_no_offenses(<<~RUBY)
-    RUBY
+    expect_no_offenses("")
   end
 
   it "does not register an offense not in a specification" do

--- a/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
   let(:message) { RuboCop::Cop::Packaging::RequireHardcodingLib::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require` call lies outside spec/" do
     let(:filename) { "#{project_root}/spec/foo_spec.rb" }

--- a/spec/rubocop/cop/packaging/require_relative_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_relative_hardcoding_lib_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::RequireRelativeHardcodingLib, :config do
   let(:message) { RuboCop::Cop::Packaging::RequireRelativeHardcodingLib::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require_relative` call lies outside spec/" do
     let(:filename) { "#{project_root}/spec/foo_spec.rb" }


### PR DESCRIPTION
https://github.com/rubocop/rubocop/commit/6b6d5542a156cb855529bc9bf536f260a4dabde6 moved `project_root` from `RuboCop::ConfigLoader.project_root` to `RuboCop::ConfigFinder.project_root`, this breaks `rubocop-packaging`.

This PR performs the required code changes to reflect this method move.

The approach I took was to set the minimum required Rubocop version to `1.33.0` and perform a "hard" move on `project_root`. This will prevent users from installing newer versions of `rubocop-packaging` with an incompatible `rubocop` version.
It's also possible to support both `RuboCop::ConfigLoader.project_root` and `RuboCop::ConfigFinder.project_root` at the same time (e.g. `defined?(RuboCop::ConfigFinder.project_root) ? RuboCop::ConfigFinder.project_root : RuboCop::ConfigLoader.project_root`), but I'm not sure if that's a better solution: it comes down to how important it is for the latest `rubocop-packaging` to work with older `rubocop` versions. I can make this change if needed.

Also, the second commit, ["Fix lint issues"](https://github.com/utkarsh2102/rubocop-packaging/commit/b4a5b2afaa45d157329ad785998cf94937626dad), is due to rubocop lint failures due to the upgrade to `1.33.0`. I added them to have a clean CI in this branch, but are technically unrelated.