### PR TITLE
Fix a build error when using RuboCop 1.33+

### DIFF
--- a/lib/rubocop/packaging/lib_helper_module.rb
+++ b/lib/rubocop/packaging/lib_helper_module.rb
@@ -7,7 +7,7 @@ module RuboCop # :nodoc:
     module LibHelperModule
       # For determining the root directory of the project.
       def root_dir
-        RuboCop::ConfigLoader.project_root
+        RuboCop::ConfigFinder.project_root
       end
 
       # This method determines if the calls are made to the "lib" directory.

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency   "rake", "~> 13.0"
   spec.add_development_dependency   "rspec", "~> 3.0"
   spec.add_development_dependency   "yard", "~> 0.9"
-  spec.add_runtime_dependency       "rubocop", ">= 1.13", "< 2.0"
+  spec.add_runtime_dependency       "rubocop", ">= 1.33", "< 2.0"
 end

--- a/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
+++ b/spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::BundlerSetupInTests, :config do
   let(:message) { RuboCop::Cop::Packaging::BundlerSetupInTests::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require bundler/setup` is used in specs/" do
     let(:filename) { "#{project_root}/spec/spec_helper.rb" }

--- a/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_hardcoding_lib_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::RequireHardcodingLib, :config do
   let(:message) { RuboCop::Cop::Packaging::RequireHardcodingLib::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require` call lies outside spec/" do
     let(:filename) { "#{project_root}/spec/foo_spec.rb" }

--- a/spec/rubocop/cop/packaging/require_relative_hardcoding_lib_spec.rb
+++ b/spec/rubocop/cop/packaging/require_relative_hardcoding_lib_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Packaging::RequireRelativeHardcodingLib, :config do
   let(:message) { RuboCop::Cop::Packaging::RequireRelativeHardcodingLib::MSG }
 
-  let(:project_root) { RuboCop::ConfigLoader.project_root }
+  let(:project_root) { RuboCop::ConfigFinder.project_root }
 
   context "when `require_relative` call lies outside spec/" do
     let(:filename) { "#{project_root}/spec/foo_spec.rb" }


### PR DESCRIPTION
Fixes #44.

Fix a build error when using RuboCop 1.33+.

The upstream will be resolved by the release of rubocop/rubocop#10872. Apart from that, this patch can be resolved by RuboCop::Packaging alone independently from the upstream.