### PR TITLE
Drop Ruby 2.5 runtime support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head]
+        ruby: ["2.6", "2.7", "3.0", "3.1", ruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Naming/FileName:
   Exclude:

--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["config/default.yml", "lib/**/*", "LICENSE", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.add_development_dependency   "bump", "~> 0.8"
   spec.add_development_dependency   "pry", "~> 0.13"


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/10577.

This PR drops Ruby 2.5 runtime support and fixes the following build error.
https://github.com/utkarsh2102/rubocop-packaging/runs/7688082957