### PR TITLE
Fix incorrect documentation URLs when using `rubocop --show-docs-url`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,9 @@
 # This is the default configuration file.
 
+Packaging:
+  Enabled: true
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-packaging
+
 Packaging/BundlerSetupInTests:
   Description: >-
                  Using `bundler/setup` in tests is redundant. Consider


### PR DESCRIPTION
Added `DocumentationBaseURL` for `rubocop --show-docs-url [COP1,COP2,...]` command to work correctly for rubocop-packaging cops.

### Before

```console
$ bundle exec rubocop --show-docs-url Packaging/BundlerSetupInTests
https://docs.rubocop.org/rubocop/cops_packaging.html#packagingbundlersetupintests
```

### After

```console
$ bundle exec rubocop --show-docs-url Packaging/BundlerSetupInTests
https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packagingbundlersetupintests
```
