### PR TITLE
 Rename IgnoredMethods to AllowedMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Naming/FileName:
 Metrics/BlockLength:
   Exclude:
     - tasks/*.rake
-  IgnoredMethods:
+  AllowedMethods:
     - configure
     - describe
     - context


### PR DESCRIPTION
IgnoredMethods is deprecated since rubocop 1.33