### PR TITLE
Fix spec failures for the GemspecGit cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.6
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-packaging.rb

--- a/spec/rubocop/cop/packaging/gemspec_git_spec.rb
+++ b/spec/rubocop/cop/packaging/gemspec_git_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Packaging::GemspecGit do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
-
+RSpec.describe RuboCop::Cop::Packaging::GemspecGit, :config do
   let(:message) { RuboCop::Cop::Packaging::GemspecGit::MSG }
 
   it "registers an offense when using `git` for :files=" do


### PR DESCRIPTION
No changes to the code, this just makes sure the cop emits the right message when running in the specs.

- Ensure consistent message format in specs for Packaging::GemspecGit
- Disable Gemspec/DevelopmentDependencies cop
