### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/rubocop-packaging.gemspec
+++ b/rubocop-packaging.gemspec
@@ -24,10 +24,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
-  spec.add_development_dependency   "bump", "~> 0.8"
-  spec.add_development_dependency   "pry", "~> 0.13"
-  spec.add_development_dependency   "rake", "~> 13.0"
-  spec.add_development_dependency   "rspec", "~> 3.0"
-  spec.add_development_dependency   "yard", "~> 0.9"
-  spec.add_runtime_dependency       "rubocop", ">= 1.33", "< 2.0"
+  spec.add_dependency "rubocop", ">= 1.33", "< 2.0"
+
+  spec.add_development_dependency "bump", "~> 0.8"
+  spec.add_development_dependency "pry", "~> 0.13"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "yard", "~> 0.9"
 end


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
