### PR TITLE
Suppress a RuboCop's offense

### DIFF
--- a/spec/rubocop/packaging_spec.rb
+++ b/spec/rubocop/packaging_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Packaging do
   describe "default configuration file" do
     subject(:config) { RuboCop::ConfigLoader.load_file("config/default.yml") }
 
-    let(:registry) { RuboCop::Cop::Cop.registry }
+    let(:registry) { RuboCop::Cop::Registry.global }
     let(:cop_names) do
       registry.with_department(:Packaging).cops.map(&:cop_name)
     end


### PR DESCRIPTION
This commit suppresses the following RuboCop's offense:

```console
$ cd path/to/rubocop-packaging
$ bundle exec rake
(snip)

/Users/koic/src/github.com/utkarsh2102/rubocop-packaging/spec/rubocop/packaging_spec.rb:13:
warning: `Cop.registry` is deprecated. Use `Registry.global` instead.
```