### PR TITLE
Fix `Packaging/RequireHardcodingLib` cop error on frozen string literal

### DIFF
--- a/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
+++ b/lib/rubocop/cop/packaging/require_hardcoding_lib.rb
@@ -99,7 +99,7 @@ module RuboCop # :nodoc:
         # And then determines if that call is made to "lib/".
         def falls_in_lib_with_file_dirname_plus_str?(str)
           @str = str
-          str.prepend(".")
+          str = ".#{str}"
           target_falls_in_lib?(str) && inspected_file_is_not_in_lib_or_gemspec?
         end
       end


### PR DESCRIPTION
Since https://github.com/ruby/prism/issues/3309 Prism emits frozen string literals.

Looks like the only place in the gem where we try to mutate a frozen literal is `require_hardcoding_lib.rb`
(`env PARSER_ENGINE=parser_prism ASDF_RUBY_VERSION=3.4.3 bundle exec rspec` fails)

I'd suggest to run tests atop of Prism in the CI.